### PR TITLE
refactor: reduce guid string conversions

### DIFF
--- a/DTOs/KnowledgeGraphDTOs/ProjectedRelationDTO.cs
+++ b/DTOs/KnowledgeGraphDTOs/ProjectedRelationDTO.cs
@@ -1,7 +1,7 @@
 // Models/ProjectedRelationDTO.cs
 public class ProjectedRelationDTO
 {
-    public string? SourceId { get; set; }
-    public string? TargetId { get; set; }
+    public Guid SourceId { get; set; }
+    public Guid TargetId { get; set; }
     public int Weight { get; set; }
 }

--- a/DTOs/KnowledgeGraphDTOs/TagContainRelationDTO.cs
+++ b/DTOs/KnowledgeGraphDTOs/TagContainRelationDTO.cs
@@ -1,6 +1,6 @@
 // Models/TagContainRelationDTO.cs
 public class TagContainRelationDTO
 {
-    public string? ParentTagId { get; set; }
-    public string? ChildTagId { get; set; }
+    public Guid ParentTagId { get; set; }
+    public Guid ChildTagId { get; set; }
 }

--- a/DTOs/KnowledgeGraphDTOs/TaggedRelationDTO.cs
+++ b/DTOs/KnowledgeGraphDTOs/TaggedRelationDTO.cs
@@ -1,6 +1,6 @@
 // Models/TaggedRelationDTO.cs
 public class TaggedRelationDTO
 {
-    public string? SourceId { get; set; }
-    public string? TagId { get; set; }
+    public Guid SourceId { get; set; }
+    public Guid TagId { get; set; }
 }

--- a/Repositories/Neo4j/INeo4jRepository.cs
+++ b/Repositories/Neo4j/INeo4jRepository.cs
@@ -9,14 +9,14 @@ public interface IGraphRepository
     /// <summary>
     /// 获取所有知识节点与纯标签节点之间的 TAGGED_WITH 关系
     /// </summary>
-    Task<List<TaggedRelationDTO>> GetTaggedRelationsAsync(IEnumerable<string> nodeIds, IEnumerable<string> tagIds);
-    Task<IEnumerable<string>> GetTagIdsInViewAsync(IEnumerable<string> zoomLevels, IEnumerable<string> allTagIds);
+    Task<List<TaggedRelationDTO>> GetTaggedRelationsAsync(IEnumerable<Guid> nodeIds, IEnumerable<Guid> tagIds);
+    Task<IEnumerable<Guid>> GetTagIdsInViewAsync(IEnumerable<string> zoomLevels, IEnumerable<Guid> allTagIds);
 
     /// <summary>
     /// 获取知识节点之间的层次关系（知识层次关系），
     /// 即标签知识节点之间按照标签体系建立的父→子关系
     /// </summary>
-    Task<List<TagContainRelationDTO>> GetPureTagContainRelationsAsync(IEnumerable<string> allTagIds);
+    Task<List<TagContainRelationDTO>> GetPureTagContainRelationsAsync(IEnumerable<Guid> allTagIds);
 
     /// <summary>
     /// 利用纯标签节点和 TAGGED_WITH 关系进行二部图投影，
@@ -27,38 +27,38 @@ public interface IGraphRepository
     /// <summary>
     /// 获取知识节点与标签层次节点之间的关系
     /// </summary>
-    Task<Dictionary<string, string>> GetNodeTagLevelRelationsAsync(IEnumerable<string> nodeIds);
+    Task<Dictionary<Guid, string>> GetNodeTagLevelRelationsAsync(IEnumerable<Guid> nodeIds);
 
     /// <summary>
     /// 获取所有与指定标签相关的知识节点
     /// </summary>
-    Task<HashSet<string>> GetAllNodesRelatedToTagsAsync(IEnumerable<string> tagIds);
+    Task<HashSet<Guid>> GetAllNodesRelatedToTagsAsync(IEnumerable<Guid> tagIds);
 
-    Task<Dictionary<Guid, string>> GetNodeLevelsByNodeIdsAsync(IEnumerable<string> nodeIds);
-    Task<HashSet<(Guid NodeId, Guid TagId, string TagLevel)>> GetNodeTagTriplesRelatedToTagsAsync(IEnumerable<string> tagIds);
-    Task<HashSet<(Guid NodeId, string NodeIdStr, Guid TagId, string TagLevel)>> GetAllNodesRelatedToTagsInViewAsync(IEnumerable<string> tagIds, IEnumerable<string> zoomLevels);
+    Task<Dictionary<Guid, string>> GetNodeLevelsByNodeIdsAsync(IEnumerable<Guid> nodeIds);
+    Task<HashSet<(Guid NodeId, Guid TagId, string TagLevel)>> GetNodeTagTriplesRelatedToTagsAsync(IEnumerable<Guid> tagIds);
+    Task<HashSet<(Guid NodeId, Guid TagId, string TagLevel)>> GetAllNodesRelatedToTagsInViewAsync(IEnumerable<Guid> tagIds, IEnumerable<string> zoomLevels);
     /// <summary>
     /// 获取所有与指定知识节点相关的标签
     /// </summary>
-    Task<HashSet<string>> GetAllTagsRelatedToNodesAsync(IEnumerable<string> nodeIds);
-    Task<HashSet<string>> GetTagsRelatedToNodeAsync(string nodeId);
-    Task<HashSet<(string TagId, string ResourceId)>> GetTagsAndResourcesIdsRelatedToNodeAsync(string nodeId);
+    Task<HashSet<Guid>> GetAllTagsRelatedToNodesAsync(IEnumerable<Guid> nodeIds);
+    Task<HashSet<Guid>> GetTagsRelatedToNodeAsync(Guid nodeId);
+    Task<HashSet<(Guid TagId, string ResourceId)>> GetTagsAndResourcesIdsRelatedToNodeAsync(string nodeId);
     /// <summary>
     /// 根据标签类型获取标签节点的 Id
     /// </summary>
-    Task<IEnumerable<string>> GetNodeIdsByLabelAsync(string label);
-    Task<HashSet<string>> GetAdjacentNodesByLevelAsync(IEnumerable<string> parentNodeIds, string targetLevel);
+    Task<IEnumerable<Guid>> GetNodeIdsByLabelAsync(string label);
+    Task<HashSet<Guid>> GetAdjacentNodesByLevelAsync(IEnumerable<Guid> parentNodeIds, string targetLevel);
     /// <summary>
     /// 获取所有与指定标签相关的知识节点
     /// </summary>
-    Task<HashSet<string>> GetAllDescendantTagIdsAsync(IEnumerable<string> tagNames);
+    Task<HashSet<Guid>> GetAllDescendantTagIdsAsync(IEnumerable<string> tagNames);
 
     /// <summary>
     /// 获取 Venn 图中标签与知识节点的分组
     /// </summary>
     Task<List<TagNodeGroup>> GetVennTagNodeGroupsAsync();
     Task<List<TagNodeGroup>> GetVennTagNodeGroupsInViewAsync(IEnumerable<string> zoomLevels);
-    Task<List<string>> GetLinkedResourceIdsAsync(IEnumerable<string> knowledgeNodeIds);
+    Task<List<string>> GetLinkedResourceIdsAsync(IEnumerable<Guid> knowledgeNodeIds);
     Task<List<string>> GetResourcesIdsRelatedToNodeAsync(string nodeId);
     Task CreateNodeAndResourceInGraphAsync(string nodeId, string name, string description, IEnumerable<string> links, string userId);
     Task<int> CountApprovedLinksByUserAsync(string userId);
@@ -81,7 +81,7 @@ public class GraphRepository : IGraphRepository
         _driver = driver;
     }
 
-    public async Task<List<TaggedRelationDTO>> GetTaggedRelationsAsync(IEnumerable<string> nodeIds, IEnumerable<string> tagIds)
+    public async Task<List<TaggedRelationDTO>> GetTaggedRelationsAsync(IEnumerable<Guid> nodeIds, IEnumerable<Guid> tagIds)
     {
         using var session = _driver.AsyncSession();
         var cypher = @"
@@ -91,21 +91,21 @@ public class GraphRepository : IGraphRepository
         ";
         var parameters = new Dictionary<string, object>
         {
-            { "nodeIds", nodeIds },
-            { "tagIds", tagIds }
+            { "nodeIds", nodeIds.Select(id => id.ToString()) },
+            { "tagIds", tagIds.Select(id => id.ToString()) }
         };
         var result = await session.RunAsync(cypher, parameters);
         return (await result.ToListAsync())
             .Select(record => new TaggedRelationDTO
             {
-                SourceId = record["SourceId"].As<string>(),
-                TagId = record["TagId"].As<string>()
+                SourceId = Guid.Parse(record["SourceId"].As<string>()),
+                TagId = Guid.Parse(record["TagId"].As<string>())
             }).ToList();
     }
 
-    public async Task<IEnumerable<string>> GetTagIdsInViewAsync(IEnumerable<string> zoomLevels, IEnumerable<string> allTagIds)
+    public async Task<IEnumerable<Guid>> GetTagIdsInViewAsync(IEnumerable<string> zoomLevels, IEnumerable<Guid> allTagIds)
     {
-        if (allTagIds == null || !allTagIds.Any()) return Enumerable.Empty<string>();
+        if (allTagIds == null || !allTagIds.Any()) return Enumerable.Empty<Guid>();
 
         using var session = _driver.AsyncSession();
         var cypher = @"
@@ -113,15 +113,14 @@ public class GraphRepository : IGraphRepository
     WHERE t.id IN $tagIds AND l.name IN $zoomLevels
     RETURN DISTINCT t.id AS TagId;
     ";
-        var result = await session.RunAsync(cypher, new { zoomLevels, tagIds = allTagIds });
+        var result = await session.RunAsync(cypher, new { zoomLevels, tagIds = allTagIds.Select(id => id.ToString()) });
         var records = await result.ToListAsync();
 
-        // Return the TagId directly as a string list, no need for additional Select
-        return records.Select(r => r["TagId"].As<string>());
+        return records.Select(r => Guid.Parse(r["TagId"].As<string>()));
     }
 
     // Repositories/GraphRepository.cs
-    public async Task<List<TagContainRelationDTO>> GetPureTagContainRelationsAsync(IEnumerable<string> allTagIds)
+    public async Task<List<TagContainRelationDTO>> GetPureTagContainRelationsAsync(IEnumerable<Guid> allTagIds)
     {
         using var session = _driver.AsyncSession();
         var cypher = @"
@@ -133,14 +132,14 @@ public class GraphRepository : IGraphRepository
     ";
         var parameters = new Dictionary<string, object>
         {
-            { "tagIds", allTagIds }
+            { "tagIds", allTagIds.Select(id => id.ToString()) }
         };
         var result = await session.RunAsync(cypher, parameters);
         return (await result.ToListAsync())
             .Select(record => new TagContainRelationDTO
             {
-                ParentTagId = record["ParentTagId"].As<string>(),
-                ChildTagId = record["ChildTagId"].As<string>()
+                ParentTagId = Guid.Parse(record["ParentTagId"].As<string>()),
+                ChildTagId = Guid.Parse(record["ChildTagId"].As<string>())
             }).ToList();
     }
 
@@ -158,13 +157,13 @@ public class GraphRepository : IGraphRepository
         return (await result.ToListAsync())
             .Select(record => new ProjectedRelationDTO
             {
-                SourceId = record["SourceId"].As<string>(),
-                TargetId = record["TargetId"].As<string>(),
+                SourceId = Guid.Parse(record["SourceId"].As<string>()),
+                TargetId = Guid.Parse(record["TargetId"].As<string>()),
                 Weight = record["weight"].As<int>()
             }).ToList();
     }
 
-    public async Task<Dictionary<string, string>> GetNodeTagLevelRelationsAsync(IEnumerable<string> nodeIds)
+    public async Task<Dictionary<Guid, string>> GetNodeTagLevelRelationsAsync(IEnumerable<Guid> nodeIds)
     {
         using var session = _driver.AsyncSession();
 
@@ -175,16 +174,16 @@ public class GraphRepository : IGraphRepository
         ";
         var parameters = new Dictionary<string, object>
         {
-            { "nodeIds", nodeIds }
+            { "nodeIds", nodeIds.Select(id => id.ToString()) }
         };
 
         var result = await session.RunAsync(query, parameters);
 
-        var nodeTagLevels = new Dictionary<string, string>();
+        var nodeTagLevels = new Dictionary<Guid, string>();
 
         await result.ForEachAsync(record =>
         {
-            var nodeId = record["NodeId"].As<string>();
+            var nodeId = Guid.Parse(record["NodeId"].As<string>());
             var tagLevelId = record["TagLevelId"].As<string>();
             nodeTagLevels[nodeId] = tagLevelId;
         });
@@ -192,7 +191,7 @@ public class GraphRepository : IGraphRepository
         return nodeTagLevels;
     }
 
-    public async Task<HashSet<string>> GetAllNodesRelatedToTagsAsync(IEnumerable<string> tagIds)
+    public async Task<HashSet<Guid>> GetAllNodesRelatedToTagsAsync(IEnumerable<Guid> tagIds)
     {
         using var session = _driver.AsyncSession();
         var query = @"
@@ -202,17 +201,17 @@ public class GraphRepository : IGraphRepository
         ";
         var parameters = new Dictionary<string, object>
         {
-            { "tagIds", tagIds }
+            { "tagIds", tagIds.Select(id => id.ToString()) }
         };
 
         var result = await session.RunAsync(query, parameters);
 
         var records = await result.ToListAsync();
 
-        return records.Select(record => record["NodeId"].As<string>()).ToHashSet();
+        return records.Select(record => Guid.Parse(record["NodeId"].As<string>())).ToHashSet();
     }
 
-    public async Task<Dictionary<Guid, string>> GetNodeLevelsByNodeIdsAsync(IEnumerable<string> nodeIds)
+    public async Task<Dictionary<Guid, string>> GetNodeLevelsByNodeIdsAsync(IEnumerable<Guid> nodeIds)
     {
         if (nodeIds == null) return new();
 
@@ -222,7 +221,7 @@ public class GraphRepository : IGraphRepository
         MATCH (n:KnowledgeNode {id: nid})<-[:TAGGED_WITH]-(l:TagLevel)
         RETURN nid AS NodeId, l.name AS TagLevel
     ";
-        var cursor = await session.RunAsync(cypher, new { nodeIds });
+        var cursor = await session.RunAsync(cypher, new { nodeIds = nodeIds.Select(id => id.ToString()) });
         var records = await cursor.ToListAsync();
 
         // 若一个节点匹配多个层级，可在这里自定义优先级（示例：取第一个）
@@ -235,7 +234,7 @@ public class GraphRepository : IGraphRepository
     }
 
     public async Task<HashSet<(Guid NodeId, Guid TagId, string TagLevel)>> GetNodeTagTriplesRelatedToTagsAsync(
-    IEnumerable<string> tagIds)
+    IEnumerable<Guid> tagIds)
     {
         using var session = _driver.AsyncSession();
         var query = @"
@@ -244,7 +243,7 @@ public class GraphRepository : IGraphRepository
         WHERE (n.status IS NULL OR n.status <> 'pending_approval')
         RETURN DISTINCT n.id AS NodeId, id AS TagId, l.name AS TagLevel
     ";
-        var result = await session.RunAsync(query, new { tagIds });
+        var result = await session.RunAsync(query, new { tagIds = tagIds.Select(id => id.ToString()) });
         var records = await result.ToListAsync();
 
         return records
@@ -256,8 +255,8 @@ public class GraphRepository : IGraphRepository
             .ToHashSet();
     }
 
-    public async Task<HashSet<(Guid NodeId, string NodeIdStr, Guid TagId, string TagLevel)>> GetAllNodesRelatedToTagsInViewAsync(
-        IEnumerable<string> tagIds, IEnumerable<string> zoomLevels)
+    public async Task<HashSet<(Guid NodeId, Guid TagId, string TagLevel)>> GetAllNodesRelatedToTagsInViewAsync(
+        IEnumerable<Guid> tagIds, IEnumerable<string> zoomLevels)
     {
         using var session = _driver.AsyncSession();
         var query = @"
@@ -268,20 +267,19 @@ public class GraphRepository : IGraphRepository
           AND (n.status IS NULL OR n.status <> 'pending_approval')
         RETURN DISTINCT n.id AS NodeId, t.id AS TagId, l.name AS TagLevel
     ";
-        var result = await session.RunAsync(query, new { tagIds, zoomLevels });
+        var result = await session.RunAsync(query, new { tagIds = tagIds.Select(id => id.ToString()), zoomLevels });
         var records = await result.ToListAsync();
 
         return records
             .Select(r => (
                 NodeId: Guid.Parse(r["NodeId"].As<string>()),
-                NodeIdStr: r["NodeId"].As<string>(),
                 TagId: Guid.Parse(r["TagId"].As<string>()),
                 TagLevel: r["TagLevel"].As<string>()
             ))
             .ToHashSet();
     }
 
-    public async Task<HashSet<string>> GetTagsRelatedToNodeAsync(string nodeId)
+    public async Task<HashSet<Guid>> GetTagsRelatedToNodeAsync(Guid nodeId)
     {
         using var session = _driver.AsyncSession();
         var query = @"
@@ -291,16 +289,16 @@ public class GraphRepository : IGraphRepository
         ";
         var parameters = new Dictionary<string, object>
         {
-            { "nodeId", nodeId }
+            { "nodeId", nodeId.ToString() }
         };
 
         var result = await session.RunAsync(query, parameters);
 
         var records = await result.ToListAsync();
-        return records.Select(record => record["TagId"].As<string>()).ToHashSet();
+        return records.Select(record => Guid.Parse(record["TagId"].As<string>())).ToHashSet();
     }
 
-    public async Task<HashSet<string>> GetAllTagsRelatedToNodesAsync(IEnumerable<string> nodeIds)
+    public async Task<HashSet<Guid>> GetAllTagsRelatedToNodesAsync(IEnumerable<Guid> nodeIds)
     {
         using var session = _driver.AsyncSession();
         var query = @"
@@ -310,16 +308,16 @@ public class GraphRepository : IGraphRepository
         ";
         var parameters = new Dictionary<string, object>
         {
-            { "nodeIds", nodeIds }
+            { "nodeIds", nodeIds.Select(id => id.ToString()) }
         };
 
         var result = await session.RunAsync(query, parameters);
 
         var records = await result.ToListAsync();
-        return records.Select(record => record["TagId"].As<string>()).ToHashSet();
+        return records.Select(record => Guid.Parse(record["TagId"].As<string>())).ToHashSet();
     }
 
-    public async Task<HashSet<(string TagId, string ResourceId)>> GetTagsAndResourcesIdsRelatedToNodeAsync(string nodeId)
+    public async Task<HashSet<(Guid TagId, string ResourceId)>> GetTagsAndResourcesIdsRelatedToNodeAsync(string nodeId)
     {
         using var session = _driver.AsyncSession();
         var query = @"
@@ -337,13 +335,13 @@ public class GraphRepository : IGraphRepository
         var records = await result.ToListAsync();
         return records
             .Select(record => (
-                TagId: record["TagId"].As<string>(),
+                TagId: Guid.Parse(record["TagId"].As<string>()),
                 ResourceId: record["ResourceId"].As<string>()
             ))
             .ToHashSet();
     }
 
-    public async Task<IEnumerable<string>> GetNodeIdsByLabelAsync(string label)
+    public async Task<IEnumerable<Guid>> GetNodeIdsByLabelAsync(string label)
     {
         // 确保 label 仅包含安全的字符（防止 Cypher 注入攻击）
         if (!Regex.IsMatch(label, "^[A-Za-z0-9_]+$"))
@@ -361,14 +359,14 @@ public class GraphRepository : IGraphRepository
 
         var result = await session.RunAsync(query);
 
-        return await result.ToListAsync(record => record["TagId"].As<string>());
+        return await result.ToListAsync(record => Guid.Parse(record["TagId"].As<string>()));
     }
 
-    public async Task<HashSet<string>> GetAllDescendantTagIdsAsync(IEnumerable<string> tagIds)
+    public async Task<HashSet<Guid>> GetAllDescendantTagIdsAsync(IEnumerable<string> tagIds)
     {
         using var session = _driver.AsyncSession();
 
-        if (!tagIds.Any()) return new HashSet<string>();
+        if (!tagIds.Any()) return new HashSet<Guid>();
 
         var query = @"
         MATCH (parent:Tag)-[:CONTAIN*]->(child:Tag)
@@ -379,7 +377,7 @@ public class GraphRepository : IGraphRepository
 
         var result = await session.RunAsync(query, parameters);
         var records = await result.ToListAsync();
-        return records.Select(record => record["tagId"].As<string>()).ToHashSet();
+        return records.Select(record => Guid.Parse(record["tagId"].As<string>())).ToHashSet();
     }
 
     public async Task<List<TagNodeGroup>> GetVennTagNodeGroupsAsync()
@@ -437,7 +435,7 @@ public class GraphRepository : IGraphRepository
         }
     }
 
-    public async Task<List<string>> GetLinkedResourceIdsAsync(IEnumerable<string> knowledgeNodeIds)
+    public async Task<List<string>> GetLinkedResourceIdsAsync(IEnumerable<Guid> knowledgeNodeIds)
     {
         if (!knowledgeNodeIds.Any())
             return new List<string>();
@@ -448,7 +446,7 @@ public class GraphRepository : IGraphRepository
         var result = await session.RunAsync(@"
         UNWIND $ids AS nodeId
         MATCH (n:KnowledgeNode {id: nodeId})-[:HAS_RESOURCE]->(r:Resource)
-        RETURN DISTINCT r.id AS resourceId", new { ids = knowledgeNodeIds });
+        RETURN DISTINCT r.id AS resourceId", new { ids = knowledgeNodeIds.Select(id => id.ToString()) });
 
         await foreach (var record in result)
         {
@@ -676,7 +674,7 @@ public class GraphRepository : IGraphRepository
         }
     }
 
-    public async Task<HashSet<string>> GetAdjacentNodesByLevelAsync(IEnumerable<string> parentNodeIds, string targetLevel)
+    public async Task<HashSet<Guid>> GetAdjacentNodesByLevelAsync(IEnumerable<Guid> parentNodeIds, string targetLevel)
     {
         using var session = _driver.AsyncSession();
 
@@ -688,13 +686,13 @@ public class GraphRepository : IGraphRepository
 
         var parameters = new Dictionary<string, object>
         {
-            { "parentIds", parentNodeIds },
+            { "parentIds", parentNodeIds.Select(id => id.ToString()) },
             { "targetLevel", targetLevel }
         };
 
         var result = await session.RunAsync(query, parameters);
         var records = await result.ToListAsync();
 
-        return records.Select(r => r["NodeId"].As<string>()).ToHashSet();
+        return records.Select(r => Guid.Parse(r["NodeId"].As<string>())).ToHashSet();
     }
 }

--- a/Services/KnowledgeGraph/KnowledgeGraphService.cs
+++ b/Services/KnowledgeGraph/KnowledgeGraphService.cs
@@ -51,20 +51,20 @@ public class KnowledgeGraphService
         var allTagIds = await _tagRepo.GetTagNodeIdsByTagTypeAsync(tagSystem);
         // var elapsed1 = DateTime.UtcNow - startTime;
         // Console.WriteLine($"GetTagNodeIdsByTagTypeAsync took {elapsed1.TotalSeconds} seconds.");
-        // var tagIdsInView = await _graphRepository.GetTagIdsInViewAsync(zoomLevels, allTagIds.Select(id => id.ToString()));
+        // var tagIdsInView = await _graphRepository.GetTagIdsInViewAsync(zoomLevels, allTagIds);
         // var elapsed2 = DateTime.UtcNow - startTime - elapsed1;
         // Console.WriteLine($"GetTagIdsInViewAsync took {elapsed2.TotalSeconds} seconds.");
 
         return viewType.ToLower() switch
         {
-            "venn" => await GetVennGraphDataInViewAsync(allTagIds.Select(id => id.ToString()), zoomLevels),
-            _ => await GetNetworkGraphDataInViewAsync(allTagIds.Select(id => id.ToString()), userId, zoomLevels)
+            "venn" => await GetVennGraphDataInViewAsync(allTagIds, zoomLevels),
+            _ => await GetNetworkGraphDataInViewAsync(allTagIds, userId, zoomLevels)
         };
     }
 
     private async Task<object> GetNetworkGraphDataAsync(IEnumerable<Guid> tagIds, string userId)
     {
-        var nodeTagTriples = await _graphRepository.GetNodeTagTriplesRelatedToTagsAsync(tagIds.Select(id => id.ToString()));
+        var nodeTagTriples = await _graphRepository.GetNodeTagTriplesRelatedToTagsAsync(tagIds);
 
         var allNodeIds = nodeTagTriples.Select(p => p.NodeId).Distinct().ToList();
 
@@ -84,7 +84,7 @@ public class KnowledgeGraphService
         return new { data };
     }
 
-    private async Task<object> GetNetworkGraphDataInViewAsync(IEnumerable<string> tagIds, string userId, IEnumerable<string> zoomLevels)
+    private async Task<object> GetNetworkGraphDataInViewAsync(IEnumerable<Guid> tagIds, string userId, IEnumerable<string> zoomLevels)
     {
         // var startTime = DateTime.UtcNow;
         var nodeTagTriples = await _graphRepository.GetAllNodesRelatedToTagsInViewAsync(tagIds, zoomLevels);
@@ -127,20 +127,13 @@ public class KnowledgeGraphService
             .ToList();
 
         // 获取包含关系（原始所有关系）
-        var allContainRelations = await _graphRepository.GetPureTagContainRelationsAsync(tagIds.Select(id => id.ToString()));
+        var allContainRelations = await _graphRepository.GetPureTagContainRelationsAsync(tagIds);
 
         // 只保留两端都在当前标签体系中的包含关系
-        var validContainRelations = new List<(Guid Parent, Guid Child)>();
-        foreach (var r in allContainRelations)
-        {
-            if (Guid.TryParse(r.ParentTagId, out Guid parentGuid) &&
-                Guid.TryParse(r.ChildTagId, out Guid childGuid) &&
-                tagIds.Contains(parentGuid) &&
-                tagIds.Contains(childGuid))
-            {
-                validContainRelations.Add((parentGuid, childGuid));
-            }
-        }
+        var validContainRelations = allContainRelations
+            .Where(r => tagIds.Contains(r.ParentTagId) && tagIds.Contains(r.ChildTagId))
+            .Select(r => (r.ParentTagId, r.ChildTagId))
+            .ToList();
 
         // 收集所有涉及的标签和节点 ID（为了查 SQL 元信息）
         var involvedTagIds = vennGroups.Select(g => g.TagId)
@@ -196,10 +189,10 @@ public class KnowledgeGraphService
         return new { venn = new { sets, contain_relations = relations } };
     }
 
-    private async Task<object> GetVennGraphDataInViewAsync(IEnumerable<string> tagIds, IEnumerable<string> zoomLevels)
+    private async Task<object> GetVennGraphDataInViewAsync(IEnumerable<Guid> tagIds, IEnumerable<string> zoomLevels)
     {
-        // 将字符串转换为 Guid 集合以便后续高效查找
-        var tagGuidSet = tagIds.Select(Guid.Parse).ToHashSet();
+        // 记录请求的标签集合，便于后续查找
+        var tagGuidSet = tagIds.ToHashSet();
 
         // 获取所有标签→节点映射（不传递）
         var allVennGroups = await _graphRepository.GetVennTagNodeGroupsInViewAsync(zoomLevels);
@@ -214,16 +207,11 @@ public class KnowledgeGraphService
 
         // 只保留两端都在当前标签体系中的包含关系
         var containRelations = allContainRelations
-            .Where(r =>
-                Guid.TryParse(r.ParentTagId, out var parentGuid) &&
-                Guid.TryParse(r.ChildTagId, out var childGuid) &&
-                tagGuidSet.Contains(parentGuid) &&
-                tagGuidSet.Contains(childGuid)
-            )
+            .Where(r => tagGuidSet.Contains(r.ParentTagId) && tagGuidSet.Contains(r.ChildTagId))
             .Select(r => new
             {
-                Parent = Guid.Parse(r.ParentTagId),
-                Child = Guid.Parse(r.ChildTagId)
+                Parent = r.ParentTagId,
+                Child = r.ChildTagId
             })
             .ToList();
 
@@ -283,18 +271,13 @@ public class KnowledgeGraphService
 
     public async Task<GraphDTO> GetAdjacentNodesByLevelAsync(IEnumerable<string> parentIds, string zoomLevel)
     {
-        var childNodeIds = await _graphRepository.GetAdjacentNodesByLevelAsync(parentIds, zoomLevel);
-        var allNodeIds = parentIds.Concat(childNodeIds).Distinct().ToList();
-
-        // allNodeIds 转换为Guid
-        var allNodeIdsGuid = allNodeIds.Select(id => Guid.Parse(id)).ToList();
+        var parentGuids = parentIds.Select(Guid.Parse).ToList();
+        var childNodeIds = await _graphRepository.GetAdjacentNodesByLevelAsync(parentGuids, zoomLevel);
+        var allNodeIds = parentGuids.Concat(childNodeIds).Distinct().ToList();
 
         var allTagIds = await _graphRepository.GetAllTagsRelatedToNodesAsync(allNodeIds);
 
-        // allTagIds 转换为 Guid
-        var allTagIdsGuid = allTagIds.Select(id => Guid.Parse(id)).ToList();
-
-        return await GetKnowledgeGraphDataByNodeId(allNodeIdsGuid, allTagIdsGuid);
+        return await GetKnowledgeGraphDataByNodeId(allNodeIds, allTagIds);
     }
 
     public async Task<IEnumerable<Guid>> GetAllKnowledgeNodeIdsAsync()
@@ -322,18 +305,15 @@ public class KnowledgeGraphService
         }
 
         // 2. 去 Neo4j 查找 TAGGED_WITH 这些知识节点的标签
-        var relatedTypeIds = await _graphRepository.GetAllTagsRelatedToNodesAsync(nodeIds.Select(id => id.ToString()));
+        var relatedTypeIds = await _graphRepository.GetAllTagsRelatedToNodesAsync(nodeIds);
 
-        // 3. 返回两个结果的交集（类型转换为 Guid）
-        var relatedTypeGuids = relatedTypeIds.Select(id => Guid.Parse(id));
-        return tagIds.Intersect(relatedTypeGuids);
+        // 3. 返回两个结果的交集
+        return tagIds.Intersect(relatedTypeIds);
     }
 
     public async Task<IEnumerable<Guid>> GetAllNodesRelatedToTags(IEnumerable<Guid> tagIds)
     {
-        // 从 SQL 获取代表节点的完整详情
-        var nodeIdsString = await _graphRepository.GetAllNodesRelatedToTagsAsync(tagIds.Select(id => id.ToString()));
-        return nodeIdsString.Select(id => Guid.Parse(id));
+        return await _graphRepository.GetAllNodesRelatedToTagsAsync(tagIds);
     }
 
     public async Task<GraphDTO> GetKnowledgeGraphDataByNodeId(IEnumerable<Guid> allNodeIds,
@@ -344,7 +324,7 @@ public class KnowledgeGraphService
         if (nodeToLevel is null)
         {
             var map = await _graphRepository
-                .GetNodeLevelsByNodeIdsAsync(allNodeIds.Select(id => id.ToString()));
+                .GetNodeLevelsByNodeIdsAsync(allNodeIds);
             nodeToLevel = map;
         }
 
@@ -392,9 +372,9 @@ public class KnowledgeGraphService
         // }
 
         // 获取所有关系
-        var taggedRelations = await _graphRepository.GetTaggedRelationsAsync(allNodeIds.Select(id => id.ToString()), allTagIds.Select(id => id.ToString()));
+        var taggedRelations = await _graphRepository.GetTaggedRelationsAsync(allNodeIds, allTagIds);
         var projectedRelations = new List<ProjectedRelationDTO>(); // 仍为空
-        var tagContainRelations = await _graphRepository.GetPureTagContainRelationsAsync(allTagIds.Select(id => id.ToString()));
+        var tagContainRelations = await _graphRepository.GetPureTagContainRelationsAsync(allTagIds);
 
         // 预构建知识节点名称到 ID 的映射（用于 CONTAIN 关系）
         var tagNameToNodeId = sqlNodes
@@ -405,10 +385,8 @@ public class KnowledgeGraphService
         var hierarchyRelations = new List<HierarchyRelationDTO>();
         foreach (var relation in tagContainRelations)
         {
-            if (Guid.TryParse(relation.ParentTagId, out var parentGuid) &&
-                Guid.TryParse(relation.ChildTagId, out var childGuid) &&
-                tagIdToName.TryGetValue(parentGuid, out var parentName) &&
-                tagIdToName.TryGetValue(childGuid, out var childName) &&
+            if (tagIdToName.TryGetValue(relation.ParentTagId, out var parentName) &&
+                tagIdToName.TryGetValue(relation.ChildTagId, out var childName) &&
                 tagNameToNodeId.TryGetValue(parentName, out var parentNodeId) &&
                 tagNameToNodeId.TryGetValue(childName, out var childNodeId))
             {
@@ -427,12 +405,12 @@ public class KnowledgeGraphService
             .ToDictionary(g => g.Key, g => g.First().Id);
 
         var replacedTaggedRelations = taggedRelations
-            .Where(t => Guid.TryParse(t.TagId, out var tagGuid) && tagIdToName.TryGetValue(tagGuid, out var tagName))
-            .Where(t => topicNodesByName.ContainsKey(tagIdToName[Guid.Parse(t.TagId)]))
+            .Where(t => tagIdToName.TryGetValue(t.TagId, out var tagName))
+            .Where(t => topicNodesByName.ContainsKey(tagIdToName[t.TagId]))
             .Select(t => new HierarchyRelationDTO
             {
-                ParentId = topicNodesByName[tagIdToName[Guid.Parse(t.TagId)]],
-                ChildId = Guid.Parse(t.SourceId)
+                ParentId = topicNodesByName[tagIdToName[t.TagId]],
+                ChildId = t.SourceId
             })
             .ToList();
 
@@ -446,8 +424,8 @@ public class KnowledgeGraphService
         }));
         linksDto.AddRange(projectedRelations.Select(r => new LinkDTO
         {
-            Source = Guid.TryParse(r.SourceId, out var sourceGuid) ? sourceGuid : Guid.Empty,
-            Target = Guid.TryParse(r.TargetId, out var targetGuid) ? targetGuid : Guid.Empty,
+            Source = r.SourceId,
+            Target = r.TargetId,
             Relation = "projected",
             Weight = r.Weight
         }));
@@ -598,7 +576,7 @@ public class KnowledgeGraphService
     public async Task<IEnumerable<Guid>> GetNodeIdsByTagsAsync(IEnumerable<string> inputTagIds)
     {
 
-        HashSet<string>? intersectionDescendantTagIds = null;
+        HashSet<Guid>? intersectionDescendantTagIds = null;
 
         // **逐个查询每个标签的所有子标签 ID，并计算交集**
         foreach (var tagId in inputTagIds)
@@ -608,7 +586,7 @@ public class KnowledgeGraphService
             if (intersectionDescendantTagIds == null)
             {
                 // 初始化交集集合
-                intersectionDescendantTagIds = new HashSet<string>(descendantTagIds);
+                intersectionDescendantTagIds = new HashSet<Guid>(descendantTagIds);
             }
             else
             {
@@ -625,7 +603,7 @@ public class KnowledgeGraphService
         if (intersectionDescendantTagIds != null && intersectionDescendantTagIds.Count > 0)
         {
             var nodeIds = await _graphRepository.GetAllNodesRelatedToTagsAsync(intersectionDescendantTagIds);
-            return nodeIds.Select(id => Guid.Parse(id));
+            return nodeIds;
         }
 
         return Enumerable.Empty<Guid>();
@@ -711,17 +689,17 @@ public class KnowledgeGraphService
             return false;
 
         // Step 2: 查找该节点关联的标签（Neo4j）
-        var tagIds = await _graphRepository.GetTagsRelatedToNodeAsync(nodeId.ToString());
+        var tagIds = await _graphRepository.GetTagsRelatedToNodeAsync(nodeId);
 
         // Step 3: 对所有 tagId，逐一处理 pending 标签草稿审核 + 主表写入 + 图状态更新
         foreach (var tagId in tagIds)
         {
-            var approved = await _tagRepo.ApproveTagDraftIfPendingAsync(Guid.Parse(tagId), reviewerId);
+            var approved = await _tagRepo.ApproveTagDraftIfPendingAsync(tagId, reviewerId);
 
             if (approved)
             {
                 // 显式更新 Neo4j 标签状态
-                await _graphRepository.SetTagStatusApprovedAsync(tagId);
+                await _graphRepository.SetTagStatusApprovedAsync(tagId.ToString());
             }
         }
 
@@ -750,12 +728,12 @@ public class KnowledgeGraphService
 
     public async Task DisapprovePendingTagsRelatedToNodeAsync(Guid nodeId)
     {
-        var tagIds = await _graphRepository.GetTagsRelatedToNodeAsync(nodeId.ToString());
+        var tagIds = await _graphRepository.GetTagsRelatedToNodeAsync(nodeId);
 
         foreach (var tagId in tagIds)
         {
             var drafts = await _context.TagDrafts
-                .Where(d => d.TagId == Guid.Parse(tagId) && d.ReviewStatus == ReviewStatus.Pending)
+                .Where(d => d.TagId == tagId && d.ReviewStatus == ReviewStatus.Pending)
                 .ToListAsync();
 
             foreach (var draft in drafts)
@@ -764,7 +742,7 @@ public class KnowledgeGraphService
                 draft.ReviewedAt = DateTimeOffset.UtcNow;
             }
 
-            await _graphRepository.SetTagStatusRejectedAsync(tagId);
+            await _graphRepository.SetTagStatusRejectedAsync(tagId.ToString());
         }
 
         await _context.SaveChangesAsync();

--- a/Services/SearchEngine/SearchService.cs
+++ b/Services/SearchEngine/SearchService.cs
@@ -22,7 +22,8 @@ public class SearchService
         // Step 2: SQL - 匹配且审核通过的 KnowledgeNode ID
         var approvedNodes = await _knowledgeRepo.SearchKnowledgeNodesAsync(query, 0, int.MaxValue);
         var approvedNodeIds = approvedNodes
-            .Select(n => n.Id.ToString()!.ToLower())
+            .Where(n => n.Id.HasValue)
+            .Select(n => n.Id!.Value)
             .ToList();
 
         // Step 3: Neo4j - 获取这些节点关联的资源 ID


### PR DESCRIPTION
## Summary
- use Guid properties across knowledge graph DTOs
- refactor Neo4j repository and service to accept Guid IDs directly
- update search service for new Guid-based repository API

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4799dca6c832ea9e3a46da48a8307