### PR TITLE
Add tag search API for knowledge graph

### DIFF
--- a/Controllers/KnowledgeNetwork/KnowledgeGraphController.cs
+++ b/Controllers/KnowledgeNetwork/KnowledgeGraphController.cs
@@ -175,6 +175,30 @@ namespace Sciencetopia.Controllers
             }
         }
 
+        [HttpGet("SearchTags")]
+        public async Task<IActionResult> SearchTags([FromQuery] string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return BadRequest("Search query is required.");
+            }
+
+            try
+            {
+                var result = await _knowledgeGraphService.SearchTagsAsync(query);
+                if (result != null)
+                {
+                    return Ok(result);
+                }
+
+                return NotFound("No tag found matching the query.");
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Internal server error: {ex.Message}");
+            }
+        }
+
         [HttpPost("CreateNode")]
         public async Task<IActionResult> CreateNode([FromBody] CreateNodeRequest request)
         {

--- a/Repositories/Sql/ITagRepository.cs
+++ b/Repositories/Sql/ITagRepository.cs
@@ -7,6 +7,7 @@ public interface ITagRepository
     Task<IEnumerable<Guid>> GetTagNodeIdsByTagTypeAsync(string tagType);
     Task<List<Tags>> GetAllTagsAsync();
     Task<List<TagDTO>> GetTagsByNameAsync(IEnumerable<string> inputTagNames);
+    Task<List<TagDTO>> SearchTagsAsync(string query);
     Task<Dictionary<Guid, (string Name, string Description, DateTimeOffset CreatedDate, DateTimeOffset UpdatedDate)>> GetTagDetailsAsync(IEnumerable<Guid> ids);
     Task<Dictionary<Guid, string>> GetTagNamesAsync(IEnumerable<Guid> ids);
     Dictionary<string, (string Name, string Description, DateTime CreatedDate, DateTime UpdatedDate)> GetRepresentativeNodes(IEnumerable<string> tagIds);
@@ -60,6 +61,27 @@ public class TagRepository : ITagRepository
         // 使用 EF Core 查询匹配的标签
         var tags = await _context.Tags
             .Where(t => inputTagNames.Contains(t.Name))
+            .Select(t => new TagDTO
+            {
+                Id = t.Id,
+                Name = t.Name
+            })
+            .ToListAsync();
+
+        return tags;
+    }
+
+    public async Task<List<TagDTO>> SearchTagsAsync(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return new List<TagDTO>();
+        }
+
+        query = query.ToLower();
+
+        var tags = await _context.Tags
+            .Where(t => t.Name != null && EF.Functions.Like(t.Name.ToLower(), $"%{query}%"))
             .Select(t => new TagDTO
             {
                 Id = t.Id,

--- a/Services/KnowledgeGraph/KnowledgeGraphService.cs
+++ b/Services/KnowledgeGraph/KnowledgeGraphService.cs
@@ -654,6 +654,11 @@ public class KnowledgeGraphService
         return await _knowledgeRepo.SearchKnowledgeNodesAsync(query.ToLower(), skip, take);
     }
 
+    public async Task<List<TagDTO>> SearchTagsAsync(string query)
+    {
+        return await _tagRepo.SearchTagsAsync(query);
+    }
+
     public async Task<string> CreateNodeAsync(CreateNodeRequest request, string userId)
     {
         return await CreateNodeWithResourcesAsync(request, userId);


### PR DESCRIPTION
## Summary
- add `SearchTags` GET endpoint in `KnowledgeGraphController`
- support tag lookup by name substring in `TagRepository`
- expose tag search through `KnowledgeGraphService`

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c5991a8c832e8839b87c2cddaacc